### PR TITLE
Fix error in Azure webapp - pyodbc module failed to install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ MarkupSafe==2.0.1
 msal==1.13.0
 pip==10.0.1
 pycparser==2.20
-pyodbc==4.0.28
+pyodbc
 pyopenssl==19.1.0
 python-dateutil==2.8.1
 python-editor==1.0.4


### PR DESCRIPTION
Azure web app does not seem to able to install `pyodbc==4.0.28`. Replaced to `pyodbc` to allow pip to solve the dependencies automatically and it worked again.